### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        # The versions should contain (at least) the lowest requirement
+        #    and a version that is more up to date.
+        toit-version: [ v2.0.0-alpha.150, latest ]
+        include:
+          - toit-version: v2.0.0-alpha.150
+            version-name: old
+          - toit-version: latest
+            version-name: new
+
+    name: CI - ${{ matrix.os }} - ${{ matrix.version-name }}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: toitlang/action-setup@v1
+        with:
+          toit-version: ${{ matrix.toit-version }}
+
+      - name: Test
+        run: |
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/tools/tmp/
+.packages/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all: test
+
+test:
+	@echo "Running tests..."
+	@for f in tests/*.toit; do \
+		echo "Running $$f"; \
+		toit $$f; \
+	done

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
 name: roboto
 description: Roboto sans-serif fonts for Toit devices.
 environment:
-  sdk: ^2.0.0-alpha.100
+  sdk: ^2.0.0-alpha.150


### PR DESCRIPTION
Also bumps the minimal version. The package works fine with older version, but Toit doesn't have a `toit` executable in earlier versions and it's not worth adapting the continuous integration for the old SDK case.